### PR TITLE
fix: version stat in tenant dashboard

### DIFF
--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -74,9 +74,11 @@
                 <x-mary-stat title="Lost" description="This month" value="34" icon="o-arrow-trending-down"
                     tooltip-left="Ops!" />
 
-                <x-mary-stat title="Current Version" description="Latest: {{ Updater::getLatestVersion() }}"
-                    value="{{ Updater::getCurrentVersion() }}" icon="o-sparkles" class="text-orange-500"
-                    color="text-pink-500" tooltip-bottom="Stay Updated!" />
+                @if (is_null(tenant('id')))
+                    <x-mary-stat title="Current Version" description="Latest: {{ Updater::getLatestVersion() }}"
+                        value="{{ Updater::getCurrentVersion() }}" icon="o-sparkles" class="text-orange-500"
+                        color="text-pink-500" tooltip-bottom="Stay Updated!" />
+                @endif
             </div>
         @else
             @yield('content')


### PR DESCRIPTION
The Updater::getCurrentVersion() and Updater::getLatestVersion() causes an error in the tenant dashboard. This patch implements a check so that the version stat will not be displayed in tenants.